### PR TITLE
Nfultz/rename alpha

### DIFF
--- a/R/HDR.R
+++ b/R/HDR.R
@@ -32,7 +32,7 @@
 #' The table above shows the parameters in each of the distributions.  Some have default values, but most need to be specified.  (For the gamma
 #' distribution you should specify either the \code{rate} or \code{scale} but not both.)
 #'
-#' @param alpha The significance level for the HDR (scalar between zero and one).  The probability coverage for the HDR is \code{1-alpha}.
+#' @param (1-cover.prob) The significance level for the HDR (scalar between zero and one).  The probability coverage for the HDR is \code{1-(1-cover.prob)}.
 #' @param shape1,shape2,ncp,location,scale,df,rate,df1,df2,meanlog,sdlog,mean,sd,min,max,shape,size,prob,m,n,k,mu,lambda Distribution parameters.
 #' @param gradtol Parameter for the nlm optimisation - a positive scalar giving the tolerance at which the scaled gradient is considered close enough to zero to terminate the algorithm (see [\code{nlm} doccumentation](https://stat.ethz.ch/R-manual/R-patched/library/stats/html/nlm.html)).
 #' @param steptol Parameter for the nlm optimisation - a positive scalar providing the minimum allowable relative step length (see [\code{nlm} doccumentation](https://stat.ethz.ch/R-manual/R-patched/library/stats/html/nlm.html)).
@@ -48,7 +48,7 @@ NULL
 #' @examples
 #' HDR.norm(.05)
 #' @rdname HDR
-HDR.norm <- function(alpha, mean = 0, sd = 1,
+HDR.norm <- function(cover.prob, mean = 0, sd = 1,
                      gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -64,12 +64,12 @@ HDR.norm <- function(alpha, mean = 0, sd = 1,
                  paste0('normal distribution with mean = ', mean,
                         ' and standard deviation = ', sd));
 
-  hdr(alpha, unimodal, Q = qnorm, f = dnorm, distribution = DIST,
+  hdr(cover.prob, unimodal, Q = qnorm, f = dnorm, distribution = DIST,
                mean = mean, sd = sd,
                gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
 #' @rdname HDR
-HDR.lnorm <- function(alpha, meanlog = 0, sdlog = 1,
+HDR.lnorm <- function(cover.prob, meanlog = 0, sdlog = 1,
                       gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -85,12 +85,12 @@ HDR.lnorm <- function(alpha, meanlog = 0, sdlog = 1,
                  paste0('log-normal distribution with log-mean = ', meanlog,
                         ' and log-standard deviation = ', sdlog));
 
-  hdr(alpha, unimodal, Q = qlnorm, f = dlnorm, distribution = DIST,
+  hdr(cover.prob, unimodal, Q = qlnorm, f = dlnorm, distribution = DIST,
            meanlog = meanlog, sdlog = sdlog,
            gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
 #' @rdname HDR
-HDR.t <- function(alpha, df, ncp = 0,
+HDR.t <- function(cover.prob, df, ncp = 0,
                   gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -107,13 +107,13 @@ HDR.t <- function(alpha, df, ncp = 0,
                  paste0('Student\'s T distribution with ', df,
                         ' degrees-of-freedom and non-centrality parameter = ', ncp));
 
-  hdr(alpha, unimodal, Q = qt, f = dt, distribution = DIST,
+  hdr(cover.prob, unimodal, Q = qt, f = dt, distribution = DIST,
                df = df, ncp = ncp,
                gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
 
 #' @rdname HDR
-HDR.cauchy <- function(alpha, location = 0, scale = 1,
+HDR.cauchy <- function(cover.prob, location = 0, scale = 1,
                        gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -129,13 +129,13 @@ HDR.cauchy <- function(alpha, location = 0, scale = 1,
                  paste0('Cauchy distribution with location = ', location,
                         ' and scale = ', scale));
 
-  hdr(alpha, unimodal, Q = qcauchy, f = dcauchy, distribution = DIST,
+  hdr(cover.prob, unimodal, Q = qcauchy, f = dcauchy, distribution = DIST,
            location = location, scale = scale,
            gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
 
 #' @rdname HDR
-HDR.f <- function(alpha, df1, df2, ncp = 0,
+HDR.f <- function(cover.prob, df1, df2, ncp = 0,
                   gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -161,7 +161,7 @@ HDR.f <- function(alpha, df1, df2, ncp = 0,
 
   modality <- if(df1 <= 2) monotone else unimodal;
 
-  HDR <- hdr(alpha, modality, qf, df, distribution = DIST,
+  HDR <- hdr(cover.prob, modality, qf, df, distribution = DIST,
                   df1 = df1, df2 = df2, ncp = ncp,
                   decreasing = TRUE,
                   gradtol = gradtol, steptol = steptol, iterlim = iterlim);
@@ -170,7 +170,7 @@ HDR.f <- function(alpha, df1, df2, ncp = 0,
 
 
 #' @rdname HDR
-HDR.beta <- function(alpha, shape1, shape2, ncp = 0,
+HDR.beta <- function(cover.prob, shape1, shape2, ncp = 0,
                      gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -218,7 +218,7 @@ HDR.beta <- function(alpha, shape1, shape2, ncp = 0,
   if ((shape1 < 1) && (shape2 < 1)) {
     modality <- bimodal;}
 
-  HDR <- hdr(alpha, modality, Q = qbeta, f = dbeta, distribution = DIST,
+  HDR <- hdr(cover.prob, modality, Q = qbeta, f = dbeta, distribution = DIST,
                   shape1 = shape1, shape2 = shape2, ncp = ncp,
                   decreasing = decreasing,
                   gradtol = gradtol, steptol = steptol, iterlim = iterlim);
@@ -227,7 +227,7 @@ HDR.beta <- function(alpha, shape1, shape2, ncp = 0,
 
 
 #' @rdname HDR
-HDR.chisq <- function(alpha, df, ncp = 0,
+HDR.chisq <- function(cover.prob, df, ncp = 0,
                       gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -253,7 +253,7 @@ HDR.chisq <- function(alpha, df, ncp = 0,
   if (df > 2) {
     modality <- unimodal; }
 
-  HDR <- hdr(alpha, modality, Q = qchisq, f = dchisq, distribution = DIST,
+  HDR <- hdr(cover.prob, modality, Q = qchisq, f = dchisq, distribution = DIST,
                   df = df, ncp = ncp,
                   gradtol = gradtol, steptol = steptol, iterlim = iterlim);
 
@@ -261,7 +261,7 @@ HDR.chisq <- function(alpha, df, ncp = 0,
 
 
 #' @rdname HDR
-HDR.gamma <- function(alpha, shape, rate = 1, scale = 1/rate,
+HDR.gamma <- function(cover.prob, shape, rate = 1, scale = 1/rate,
                       gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -291,7 +291,7 @@ HDR.gamma <- function(alpha, shape, rate = 1, scale = 1/rate,
   #Compute HDR in unimodal case;
   if (shape > 1) { modality <- unimodal; }
 
-  HDR <- hdr(alpha, modality, Q = qgamma, f = dgamma, distribution = DIST,
+  HDR <- hdr(cover.prob, modality, Q = qgamma, f = dgamma, distribution = DIST,
                   shape = shape,  scale = scale,
                   gradtol = gradtol, steptol = steptol, iterlim = iterlim);
 
@@ -299,7 +299,7 @@ HDR.gamma <- function(alpha, shape, rate = 1, scale = 1/rate,
 
 
 #' @rdname HDR
-HDR.weibull <- function(alpha, shape, scale = 1,
+HDR.weibull <- function(cover.prob, shape, scale = 1,
                         gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -323,7 +323,7 @@ HDR.weibull <- function(alpha, shape, scale = 1,
   if (shape > 1) { modality <- unimodal; }
 
 
-  HDR <- hdr(alpha, modality, Q = qweibull, f = dweibull, distribution = DIST,
+  HDR <- hdr(cover.prob, modality, Q = qweibull, f = dweibull, distribution = DIST,
                       shape = shape, scale = scale,
                       decreasing = TRUE,
                       gradtol = gradtol, steptol = steptol, iterlim = iterlim);
@@ -332,7 +332,7 @@ HDR.weibull <- function(alpha, shape, scale = 1,
 
 
 #' @rdname HDR
-HDR.exp <- function(alpha, rate,
+HDR.exp <- function(cover.prob, rate,
                     gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -344,13 +344,13 @@ HDR.exp <- function(alpha, rate,
   DIST <- paste0('exponential distribution with scale = ', 1/rate);
 
   #Compute the HDR
-  hdr(alpha, monotone, Q = qexp, f = dexp, distribution = DIST,
+  hdr(cover.prob, monotone, Q = qexp, f = dexp, distribution = DIST,
            rate = rate,
            decreasing = TRUE);}
 
 
 #' @rdname HDR
-HDR.unif <- function(alpha, min = 0, max = 1,
+HDR.unif <- function(cover.prob, min = 0, max = 1,
                      gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -366,7 +366,7 @@ HDR.unif <- function(alpha, min = 0, max = 1,
                  paste0('continuous uniform distribution with minimum = ', min,
                         ' and maximum = ', max));
 
-  hdr(alpha, unimodal, Q = qunif, f = dunif, distribution = DIST,
+  hdr(cover.prob, unimodal, Q = qunif, f = dunif, distribution = DIST,
            min = min, max = max,
            gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
@@ -374,7 +374,7 @@ HDR.unif <- function(alpha, min = 0, max = 1,
 
 
 #' @rdname HDR
-HDR.hyper <- function(alpha, m, n, k,
+HDR.hyper <- function(cover.prob, m, n, k,
                       gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -394,13 +394,13 @@ HDR.hyper <- function(alpha, m, n, k,
   DIST <- paste0('hypergeometric distribution with ', m, ' white balls, ', n,
                  ' black balls, and ', k, ' balls drawn');
 
-  hdr(alpha, modality=discrete.unimodal, Q = qhyper, F = phyper, distribution = DIST,
+  hdr(cover.prob, modality=discrete.unimodal, Q = qhyper, F = phyper, distribution = DIST,
            m = m, n = n, k = k,
            gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
 
 #' @rdname HDR
-HDR.geom <- function(alpha, prob,
+HDR.geom <- function(cover.prob, prob,
                      gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -413,13 +413,13 @@ HDR.geom <- function(alpha, prob,
   #Set text for distribution
   DIST <- paste0('geometric distribution with probability = ', prob);
 
-  hdr(alpha, discrete.unimodal, Q = qgeom, F = pgeom, distribution = DIST,
+  hdr(cover.prob, discrete.unimodal, Q = qgeom, F = pgeom, distribution = DIST,
                         prob = prob,
                         gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
 
 #' @rdname HDR
-HDR.binom <- function(alpha, size, prob,
+HDR.binom <- function(cover.prob, size, prob,
                       gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -435,13 +435,13 @@ HDR.binom <- function(alpha, size, prob,
   DIST <- paste0('binomial distribution with size = ', size,
                  ' and probability = ', prob);
 
-  hdr(alpha, discrete.unimodal, Q = qbinom, F = pbinom, distribution = DIST,
+  hdr(cover.prob, discrete.unimodal, Q = qbinom, F = pbinom, distribution = DIST,
            size = size, prob = prob,
                         gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
 
 #' @rdname HDR
-HDR.pois <- function(alpha, lambda,
+HDR.pois <- function(cover.prob, lambda,
                      gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -452,13 +452,13 @@ HDR.pois <- function(alpha, lambda,
   #Set text for distribution
   DIST <- paste0('Poisson distribution with rate = ', lambda);
 
-  hdr(alpha, discrete.unimodal, Q = qpois, F = ppois, distribution = DIST,
+  hdr(cover.prob, discrete.unimodal, Q = qpois, F = ppois, distribution = DIST,
                         lambda = lambda,
                         gradtol = gradtol, steptol = steptol, iterlim = iterlim); }
 
 
 #' @rdname HDR
-HDR.nbinom <- function(alpha, size, prob, mu,
+HDR.nbinom <- function(cover.prob, size, prob, mu,
                        gradtol = 1e-10, steptol = 1e-10, iterlim = 100) {
 
   #Check inputs
@@ -496,7 +496,7 @@ HDR.nbinom <- function(alpha, size, prob, mu,
                         size, ' and mean = ', mu));
 
 
-  hdr(alpha, discrete.unimodal, 
+  hdr(cover.prob, discrete.unimodal, 
            #Q = qnbinom, F = pbinom, 
            Q = QQ, F = FF, 
            distribution = DIST,

--- a/R/HDR.R
+++ b/R/HDR.R
@@ -32,7 +32,7 @@
 #' The table above shows the parameters in each of the distributions.  Some have default values, but most need to be specified.  (For the gamma
 #' distribution you should specify either the \code{rate} or \code{scale} but not both.)
 #'
-#' @param (1-cover.prob) The significance level for the HDR (scalar between zero and one).  The probability coverage for the HDR is \code{1-(1-cover.prob)}.
+#' @param cover.prob The probability coverage for the HDR (scalar between zero and one).  The significance level for the HDR i is \code{1-cover.prob}.  
 #' @param shape1,shape2,ncp,location,scale,df,rate,df1,df2,meanlog,sdlog,mean,sd,min,max,shape,size,prob,m,n,k,mu,lambda Distribution parameters.
 #' @param gradtol Parameter for the nlm optimisation - a positive scalar giving the tolerance at which the scaled gradient is considered close enough to zero to terminate the algorithm (see [\code{nlm} doccumentation](https://stat.ethz.ch/R-manual/R-patched/library/stats/html/nlm.html)).
 #' @param steptol Parameter for the nlm optimisation - a positive scalar providing the minimum allowable relative step length (see [\code{nlm} doccumentation](https://stat.ethz.ch/R-manual/R-patched/library/stats/html/nlm.html)).

--- a/man/HDR.Rd
+++ b/man/HDR.Rd
@@ -21,7 +21,7 @@
 \title{Highest density region (HDR)}
 \usage{
 HDR.norm(
-  alpha,
+  cover.prob,
   mean = 0,
   sd = 1,
   gradtol = 1e-10,
@@ -30,7 +30,7 @@ HDR.norm(
 )
 
 HDR.lnorm(
-  alpha,
+  cover.prob,
   meanlog = 0,
   sdlog = 1,
   gradtol = 1e-10,
@@ -38,10 +38,10 @@ HDR.lnorm(
   iterlim = 100
 )
 
-HDR.t(alpha, df, ncp = 0, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
+HDR.t(cover.prob, df, ncp = 0, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
 
 HDR.cauchy(
-  alpha,
+  cover.prob,
   location = 0,
   scale = 1,
   gradtol = 1e-10,
@@ -50,7 +50,7 @@ HDR.cauchy(
 )
 
 HDR.f(
-  alpha,
+  cover.prob,
   df1,
   df2,
   ncp = 0,
@@ -60,7 +60,7 @@ HDR.f(
 )
 
 HDR.beta(
-  alpha,
+  cover.prob,
   shape1,
   shape2,
   ncp = 0,
@@ -69,10 +69,17 @@ HDR.beta(
   iterlim = 100
 )
 
-HDR.chisq(alpha, df, ncp = 0, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
+HDR.chisq(
+  cover.prob,
+  df,
+  ncp = 0,
+  gradtol = 1e-10,
+  steptol = 1e-10,
+  iterlim = 100
+)
 
 HDR.gamma(
-  alpha,
+  cover.prob,
   shape,
   rate = 1,
   scale = 1/rate,
@@ -82,7 +89,7 @@ HDR.gamma(
 )
 
 HDR.weibull(
-  alpha,
+  cover.prob,
   shape,
   scale = 1,
   gradtol = 1e-10,
@@ -90,10 +97,10 @@ HDR.weibull(
   iterlim = 100
 )
 
-HDR.exp(alpha, rate, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
+HDR.exp(cover.prob, rate, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
 
 HDR.unif(
-  alpha,
+  cover.prob,
   min = 0,
   max = 1,
   gradtol = 1e-10,
@@ -101,16 +108,23 @@ HDR.unif(
   iterlim = 100
 )
 
-HDR.hyper(alpha, m, n, k, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
+HDR.hyper(cover.prob, m, n, k, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
 
-HDR.geom(alpha, prob, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
+HDR.geom(cover.prob, prob, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
 
-HDR.binom(alpha, size, prob, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
+HDR.binom(
+  cover.prob,
+  size,
+  prob,
+  gradtol = 1e-10,
+  steptol = 1e-10,
+  iterlim = 100
+)
 
-HDR.pois(alpha, lambda, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
+HDR.pois(cover.prob, lambda, gradtol = 1e-10, steptol = 1e-10, iterlim = 100)
 
 HDR.nbinom(
-  alpha,
+  cover.prob,
   size,
   prob,
   mu,
@@ -120,7 +134,7 @@ HDR.nbinom(
 )
 }
 \arguments{
-\item{alpha}{The significance level for the HDR (scalar between zero and one).  The probability coverage for the HDR is \code{1-alpha}.}
+\item{cover.prob}{The probability coverage for the HDR (scalar between zero and one).  The significance level for the HDR i is \code{1-cover.prob}.}
 
 \item{gradtol}{Parameter for the nlm optimisation - a positive scalar giving the tolerance at which the scaled gradient is considered close enough to zero to terminate the algorithm (see [\code{nlm} doccumentation](https://stat.ethz.ch/R-manual/R-patched/library/stats/html/nlm.html)).}
 

--- a/tests/test-HDR.R
+++ b/tests/test-HDR.R
@@ -1,28 +1,28 @@
 
 
 stopifnot(all.equal(
-  stat.extend::HDR.norm(.05,1,3),
+  stat.extend::HDR.norm(1-.05,1,3),
   structure(list(list(l = -4.87989195362016, r = 6.87989195362016, 
                       lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 0 iterations (code = 1)", probability = 0.95, distribution = "normal distribution with mean = 1 and standard deviation = 3")
 ))
 
 
 stopifnot(all.equal(
-  stat.extend::HDR.lnorm(.05, 1, .3),
+  stat.extend::HDR.lnorm(1-.05, 1, .3),
   structure(list(list(l = 1.34512113868324, r = 4.58832908980926, 
                       lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 7 iterations (code = 1)", probability = 0.95, distribution = "log-normal distribution with log-mean = 1 and log-standard deviation = 0.3")
 ))
 
 
 stopifnot(all.equal(
-  stat.extend::HDR.t(.05, 29, .3),
+  stat.extend::HDR.t(1-.05, 29, .3),
   structure(list(list(l = -1.73385540922536, r = 2.35964477149638, 
                       lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 4 iterations (code = 1)", probability = 0.95, distribution = "Student's T distribution with 29 degrees-of-freedom and non-centrality parameter = 0.3")
 ))
 
 
 stopifnot(all.equal(
-  stat.extend::HDR.cauchy(.05, 1, 2),
+  stat.extend::HDR.cauchy(1-.05, 1, 2),
   structure(list(list(l = -24.4124094723494, r = 26.4124094723493, 
                       lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 0 iterations (code = 1)", probability = 0.95, distribution = "Cauchy distribution with location = 1 and scale = 2")
   
@@ -31,49 +31,49 @@ stopifnot(all.equal(
 
 # monotone
 stopifnot(all.equal(
-  stat.extend::HDR.f(.05, 1, 2, 3),
+  stat.extend::HDR.f(1-.05, 1, 2, 3),
   structure(list(list(l = 0, r = 76.2364236939022, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                                      "interval"), domain = "R", method = "Computed using monotone optimisation", probability = 0.95, distribution = "F distribution with 1 numerator degrees-of-freedom and 2 denominator degrees-of-freedom and non-centrality parameter = 3")
 ))
 
 # unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.f(.05, 3, 2, 3),
+  stat.extend::HDR.f(1-.05, 3, 2, 3),
   structure(list(list(l = 6.68324314416018e-13, r = 38.4926454487213, 
                       lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 1 iteration (code = 1)", probability = 0.95, distribution = "F distribution with 3 numerator degrees-of-freedom and 2 denominator degrees-of-freedom and non-centrality parameter = 3")  
 ))
 
 #monotone down
 stopifnot(all.equal(
-  stat.extend::HDR.beta(.05, 1, 2),
+  stat.extend::HDR.beta(1-.05, 1, 2),
   structure(list(list(l = 0, r = 0.776393202250021, lc = TRUE, 
                       rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using monotone optimisation", probability = 0.95, distribution = "beta distribution with shape1 = 1 and shape2 = 2")
 ))
 
 # monotone up
 stopifnot(all.equal(
-  stat.extend::HDR.beta(.05, 2, 1),
+  stat.extend::HDR.beta(1-.05, 2, 1),
   structure(list(list(l = 0.223606797749979, r = 1, lc = TRUE, 
                       rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using monotone optimisation", probability = 0.95, distribution = "beta distribution with shape1 = 2 and shape2 = 1")
 ))
 
 # beta(1,1) => uniform
 stopifnot(all.equal(
-  stat.extend::HDR.beta(.05, 1, 1),
+  stat.extend::HDR.beta(1-.05, 1, 1),
   structure(list(list(l = 0.025, r = 0.975, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                               "interval"), domain = "R", method = "Computed using nlm optimisation with 0 iterations (code = 1)", probability = 0.95, distribution = "standard uniform distribution")  
 ))
 
 # unimodal
 stopifnot(all.equal(
-stat.extend::HDR.beta(.05, 2, 2),
+stat.extend::HDR.beta(1-.05, 2, 2),
 structure(list(list(l = 0.0942993240502461, r = 0.905700675949753, 
                     lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 0 iterations (code = 1)", probability = 0.95, distribution = "beta distribution with shape1 = 2 and shape2 = 2")
 ))
 
 # bimodal
 stopifnot(all.equal(
-  stat.extend::HDR.beta(.05, .1, .1),
+  stat.extend::HDR.beta(1-.05, .1, .1),
   structure(list(list(l = 0, r = 0.361776246451287, lc = TRUE,
                       rc = TRUE), list(l = 0.638223753548714, r = 1, lc = TRUE, 
                                        rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 0 iterations (code = 1)", probability = 0.95, distribution = "beta distribution with shape1 = 0.1 and shape2 = 0.1")
@@ -81,14 +81,14 @@ stopifnot(all.equal(
 
 # Monotone 
 stopifnot(all.equal(
-  stat.extend::HDR.chisq(.05, 2, .1),
+  stat.extend::HDR.chisq(1-.05, 2, .1),
   structure(list(list(l = 0, r = 6.28726305532095, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                                      "interval"), domain = "R", method = "Computed using monotone optimisation", probability = 0.95, distribution = "chi-squared distribution with 2 degrees-of-freedom and non-centrality parameter = 0.1")
 ))
 
 # Unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.chisq(.05, 200, .1),
+  stat.extend::HDR.chisq(1-.05, 200, .1),
   structure(list(list(l = 161.567164972462, r = 239.761750052931, 
                       lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 4 iterations (code = 1)", probability = 0.95, distribution = "chi-squared distribution with 200 degrees-of-freedom and non-centrality parameter = 0.1")
 ))
@@ -97,7 +97,7 @@ stopifnot(all.equal(
 
 # Gamma(1, x) => Exponential(x)
 stopifnot(all.equal(
-  stat.extend::HDR.gamma(.05, shape = 1, scale=5),
+  stat.extend::HDR.gamma(1-.05, shape = 1, scale=5),
   structure(list(list(l = 0, r = 14.97866136777, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                                    "interval"), domain = "R", method = "Computed using monotone optimisation", probability = 0.95, distribution = "exponential distribution with scale = 5")  
 ))
@@ -105,91 +105,91 @@ stopifnot(all.equal(
 
 # Unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.gamma(.05, shape = 2, scale=5),
+  stat.extend::HDR.gamma(1-.05, shape = 2, scale=5),
   structure(list(list(l = 0.211816667149859, r = 23.8258412369454, 
                       lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 10 iterations (code = 1)", probability = 0.95, distribution = "gamma distribution with shape = 2 and scale = 5")
 ))
 
 # Weibull(1, X) => Exponential(x)
 stopifnot(all.equal(
-  stat.extend::HDR.weibull(.05, shape = 1, scale=5),
+  stat.extend::HDR.weibull(1-.05, shape = 1, scale=5),
   structure(list(list(l = 0, r = 14.97866136777, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                                    "interval"), domain = "R", method = "Computed using monotone optimisation", probability = 0.95, distribution = "exponential distribution with scale = 5")
 ))
 
 # unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.weibull(.05, shape = 2, scale=5),
+  stat.extend::HDR.weibull(1-.05, shape = 2, scale=5),
   structure(list(list(l = 0.390576258175476, r = 8.83948980233535, 
                       lc = TRUE, rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using nlm optimisation with 8 iterations (code = 1)", probability = 0.95, distribution = "Weibull distribution with shape = 2 and scale = 5")
 ))
 
 # Monotone down
 stopifnot(all.equal(
-  stat.extend::HDR.exp(.05, rate=5),
+  stat.extend::HDR.exp(1-.05, rate=5),
   structure(list(list(l = 0, r = 0.599146454710798, lc = TRUE, 
                       rc = TRUE)), class = c("hdr", "interval"), domain = "R", method = "Computed using monotone optimisation", probability = 0.95, distribution = "exponential distribution with scale = 0.2")
 ))
 
 # Unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.unif(.05),
+  stat.extend::HDR.unif(1-.05),
   structure(list(list(l = 0.025, r = 0.975, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                               "interval"), domain = "R", method = "Computed using nlm optimisation with 0 iterations (code = 1)", probability = 0.95, distribution = "continuous uniform distribution with minimum = 0 and maximum = 1")
 ))
 
 #Discrete unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.hyper(.05, 50, 5, 5),
+  stat.extend::HDR.hyper(1-.05, 50, 5, 5),
   structure(list(list(l = 3, r = 5, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                       "interval"), domain = "Z", probability = 0.996406479203372, method = "Computed using discrete optimisation with minimum coverage probability = 95.00%", distribution = "hypergeometric distribution with 50 white balls, 5 black balls, and 5 balls drawn")
 ))
 
 # Discrete unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.geom(.05, .50),
+  stat.extend::HDR.geom(1-.05, .50),
   structure(list(list(l = 0, r = 4, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                       "interval"), domain = "Z", probability = 0.96875, method = "Computed using discrete optimisation with minimum coverage probability = 95.00%", distribution = "geometric distribution with probability = 0.5")
 ))
 
 # Discrete unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.binom(.05, 20, .50),
+  stat.extend::HDR.binom(1-.05, 20, .50),
   structure(list(list(l = 6, r = 14, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                        "interval"), domain = "Z", probability = 0.958610534667969, method = "Computed using discrete optimisation with minimum coverage probability = 95.00%", distribution = "binomial distribution with size = 20 and probability = 0.5")
 ))
 
 # discrete unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.pois(.05, 20,),
+  stat.extend::HDR.pois(1-.05, 20,),
   structure(list(list(l = 12, r = 29, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                         "interval"), domain = "Z", probability = 0.956794960887162, method = "Computed using discrete optimisation with minimum coverage probability = 95.00%", distribution = "Poisson distribution with rate = 20")
 ))
 
 # Discrete unimodal
 stopifnot(all.equal(
-  stat.extend::HDR.nbinom(.05, 10, .20),
+  stat.extend::HDR.nbinom(1-.05, 10, .20),
   structure(list(list(l = 15, r = 68, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                         "interval"), domain = "Z", probability = 0.951352378174766, method = "Computed using discrete optimisation with minimum coverage probability = 95.00%", distribution = "negative binomial distribution with size = 10 and probability = 0.2")
 ))
 
 # nbinom "mu mode"
 stopifnot(all.equal(
-  stat.extend::HDR.nbinom(.05, 4, mu=3),
+  stat.extend::HDR.nbinom(1-.05, 4, mu=3),
   structure(list(list(l = 0, r = 7, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                     "interval"), domain = "Z", probability = 0.95479730230908, method = "Computed using discrete optimisation with minimum coverage probability = 95.00%", distribution = "negative binomial distribution with size = 4 and mean = 3")
 ))
 
 # short circuit when alpha = 1
 stopifnot(all.equal(
-  stat.extend::HDR.norm(0, 10, .20),
+  stat.extend::HDR.norm(1-0, 10, .20),
   structure(list(list(l = -Inf, r = Inf, lc = TRUE, rc = TRUE)), class = c("hdr", 
                                                                            "interval"), domain = "R", method = NA_character_, probability = 1, distribution = "normal distribution with mean = 10 and standard deviation = 0.2")
 ))
 
 # short circuit when alpha = 0
 stopifnot(all.equal(
-  stat.extend::HDR.norm(1, 10, .20),
+  stat.extend::HDR.norm(1-1, 10, .20),
   structure(list(), class = c("hdr", "interval"), domain = NA, method = NA_character_, probability = 0, distribution = "normal distribution with mean = 10 and standard deviation = 0.2")
 ))
 


### PR DESCRIPTION
I've renamed the `alpha` parameter to cover.prob using find-replace / regexes:

```{bash}
sed -i -e "s/function[(]alpha/function(cover.prob/g" \
       -e "s/alpha=/cover.prob=/g" \
       -e "s/alpha/(1-cover.prob)/g"\
       -e "s/hdr((1-cover.prob)/hdr(cover.prob/" \
       -e "s/cover.prob=(1-cover.prob)/cover.prob=cover.prob/" R/*.R

sed -i -e "s/HDR\([.][a-z]*\)[(]/HDR\1(1-/" tests/*.R
```


Other names to consider:
  * coverage